### PR TITLE
add missing custom-requirements.txt to Pike

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,0 +1,5 @@
+# monitoring
+git+https://github.com/sapcc/openstack-ops-middleware.git
+
+# audit trail
+git+https://github.com/sapcc/openstack-audit-middleware.git


### PR DESCRIPTION
the custom-requirements.txt from mitaka-m3 is missing from pike-m3