### PR TITLE
Pin Twisted to pre 20 for vendored raven

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -545,3 +545,4 @@ actdiag===0.5.4
 sysv-ipc===0.7.0
 scikit-learn===0.19.1
 python-blazarclient===1.0.1
+Twisted<20


### PR DESCRIPTION
With Twisted 20.3.0rc1 our vendored version of raven does not work
properly anymore, as this exception is thrown:

[...]
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/__init__.py", line 49, in <module>
    from raven.base import *  # NOQA
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/base.py", line 37, in <module>
    from raven.conf.remote import RemoteConfig
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/conf/remote.py", line 36, in <module>
    DEFAULT_TRANSPORT = discover_default_transport()
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/conf/remote.py", line 18, in discover_default_transport
    from raven.transport.threaded import ThreadedHTTPTransport
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/transport/__init__.py", line 18, in <module>
    from raven.transport.registry import *  # NOQA
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/transport/registry.py", line 18, in <module>
    from raven.transport.twisted import TwistedHTTPTransport
  File "/var/lib/openstack/local/lib/python2.7/site-packages/raven/transport/twisted.py", line 16, in <module>
    from twisted.web.client import (
  File "/var/lib/openstack/local/lib/python2.7/site-packages/twisted/web/client.py", line 38, in <module>
    from twisted.web import http
  File "/var/lib/openstack/local/lib/python2.7/site-packages/twisted/web/http.py", line 102, in <module>
    from twisted.internet import interfaces, protocol, address
  File "/var/lib/openstack/local/lib/python2.7/site-packages/twisted/internet/address.py", line 101, in <module>
    @attr.s(hash=False, repr=False, eq=False)
TypeError: attrs() got an unexpected keyword argument 'eq'

Last known working version is 19.10.0, therefore we pin Twisted to
pre-20.