### PR TITLE
Use custom os-brick and oslo.vmware

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -283,7 +283,7 @@ funcparserlib===0.3.6
 passlib===1.7.1
 dib-utils===0.0.11
 cliff===2.16.0
-os-brick===2.10.2
+git+https://github.com/sapcc/os-brick.git@stable/train-m3#egg=os-brick
 ansible-runner===1.3.4
 trollius===2.2.post1;python_version=='2.7'
 scp===0.13.2
@@ -374,7 +374,7 @@ s3transfer===0.2.1
 text-unidecode===1.2
 sphinxcontrib-svg2pdfconverter===0.1.0
 murano-pkg-check===0.3.0
-oslo.vmware===2.34.1
+git+https://github.com/sapcc/oslo.vmware.git@stable/train-m3#egg=oslo.vmware
 sqlalchemy-migrate===0.12.0
 python-monascaclient===1.16.0
 ldap3===2.6.1


### PR DESCRIPTION
This patch updates the train-m3 branch to use the sapcc
custom version of os-brick and oslo.vmware to support
ccloud.