### PR TITLE
SAP fix neutron-lib pinning

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -65,7 +65,7 @@ skydive-client===0.5.0
 pysendfile===2.0.1
 fixtures===3.0.0
 #neutron===15.0.2
-neutron-lib===1.29.3.dev2
+neutron-lib===1.29.2
 XStatic-FileSaver===1.3.2.0
 storage-interfaces===1.0.3
 persist-queue===0.4.2


### PR DESCRIPTION
This patch fixes the neutron-lib pinning to 1.29.2 which is the
latest available upstream for train.