### PR TITLE
Bump jaeger-client version to 4.1.0

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -483,7 +483,7 @@ tenacity===5.0.3
 python-designateclient===2.11.0
 future===0.17.1
 Paste===3.0.7
-jaeger-client===3.13.0
+jaeger-client===4.1.0
 XStatic-Json2yaml===0.1.1.0
 boto===2.49.0
 functools32===3.2.3.post2;python_version=='2.7'


### PR DESCRIPTION
Three reasons:
- Octavia is our only service on Stein at the time being
- Keystone/Cinder/... use this jaeger-client version as well and they work
- jaeger-client 3.13.0 crashed each time a request with tracing info was sent.