### PR TITLE
Bump pyroute2 to 0.5.15 for performance

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -266,7 +266,7 @@ semantic-version===2.8.4
 virtualbmc===2.0.0
 deprecation===2.0.7
 SQLAlchemy===1.3.16
-pyroute2===0.5.11
+pyroute2===0.5.15
 google-auth===1.13.1
 kazoo===2.7.0
 XStatic-roboto-fontface===0.5.0.0


### PR DESCRIPTION
pyroute2 has optimized netlink parsing amongst other improvements. This
leads to some calls like get_links() requiring only half the time per
call. This gives us a significant speedup for network agent operations.
0.5.15 is the closest version to 0.5.11 that already has the required
performance patches.