### PR TITLE
Cap setuptools in upper-constraints

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -699,3 +699,5 @@ Pygments===2.6.1;python_version=='3.7'
 edgegrid-python===1.1.1
 python-redis===0.2.2
 crc16===0.1.1
+setuptools===44.1.1;python_version=='2.7'
+setuptools===57.5.0;python_version=='3.7'


### PR DESCRIPTION
This will be in line with upstream [0] and will help fix issues similar to [1]. A similar change was already merged in https://github.com/sapcc/requirements/pull/36

[0]https://opendev.org/openstack/requirements/raw/branch/stable/train/upper-constraints.txt
[1]https://bugs.launchpad.net/tripleo/+bug/1962232