### PR TITLE
Python 3.7: importlib-metadata<5.0

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -303,6 +303,7 @@ nodeenv===1.6.0
 gossip===2.4.0
 suds-community===1.0.0
 importlib-metadata===4.11.1;python_version=='3.8'
+importlib-metadata<5.0;python_version=='3.7'
 importlib-metadata===4.8.3;python_version=='3.6'
 oslo.middleware===4.5.1
 XStatic-mdi===1.6.50.2


### PR DESCRIPTION
importlib-metadata 5.0 removed support for dict-style interaction with entrypoints [1]
This means that stevedore does not support this kind of interaction anymore as well [2] when used with Python 3.7, which is the only python version where the third-party importlib-metadata package is required rather than the [stdlib importlib.metadata package](https://docs.python.org/3/library/importlib.metadata.html), as explained in [3]
A fix has been rolled out to stevedore [3], but it not in a release yet, so we need to manually constrain the importlib-metadata version, which is what this PR does.
This issue was found due to Octavia GitHub actions still using Python 3.7 [4]

[1] importlib-metadata commit removing support for dict-style interaction with entrypoints: https://github.com/python/importlib_metadata/commit/dde2b9de2973ce1c6fa9ba21dfe81069b0baa77b
[2] importlib-metadata 5.0 breaks stevedore: https://bugs.launchpad.net/python-stevedore/+bug/1991559
[3] Gerrit code review for stevedore fix: https://review.opendev.org/c/openstack/stevedore/+/860105
[4] Debugging of failing Octavia GitHub actions: https://convergedcloud.slack.com/archives/G6A1L7X6U/p1664966626308789