### PR TITLE
Make yappi in oslo.services optional

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -36,7 +36,7 @@ setproctitle===1.3.2
 pytest===7.1.2
 python-slugify===6.1.2
 cursive===0.2.2
-oslo.service===3.0.0
+oslo.service @ git+https://github.com/sapcc/oslo.service.git@stable/zed-m3
 django-appconf===1.0.5
 sphinxcontrib-nwdiag===2.0.0
 rbd-iscsi-client===0.1.8


### PR DESCRIPTION
This removes the profiling command 'prof', unless
yappi is installed.
The package is incompatible with gevent and python 3.11