### PR TITLE
Pin Yappi to version 1.4.0

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -475,7 +475,7 @@ nocaselist===1.0.6
 oslo.db===12.1.0
 simplegeneric===0.8.1
 python-pcre===0.7
-yappi===1.3.6
+yappi===1.4.0
 mbstrdecoder===1.1.1
 abclient===0.2.3
 pymemcache===3.5.2

--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -36,7 +36,7 @@ setproctitle===1.3.2
 pytest===7.1.2
 python-slugify===6.1.2
 cursive===0.2.2
-oslo.service @ git+https://github.com/sapcc/oslo.service.git@stable/zed-m3
+oslo.service===3.0.0
 django-appconf===1.0.5
 sphinxcontrib-nwdiag===2.0.0
 rbd-iscsi-client===0.1.8


### PR DESCRIPTION
Older versions fail to build with Python 3.11 [1]. This breaks tox environments when running it with Python 3.11.

[1]: https://github.com/sumerc/yappi/issues/104

Change-Id: I085e68fa90e85e5d48c76f863cb230b7073a3919