### PR TITLE
Revert "Add pyroscope-io for profiling"

### DIFF
--- a/custom-requirements.txt
+++ b/custom-requirements.txt
@@ -1,4 +1,3 @@
 git+https://github.com/sapcc/openstack-watcher-middleware.git
 git+https://github.com/sapcc/openstack-audit-middleware.git
 git+https://github.com/sapcc/raven-python.git@ccloud#egg=raven
-pyroscope-io~=0.8.1


### PR DESCRIPTION
This reverts commit eec1dbd8bbdc832027f6f232c1f4cc567e7c5a28.

Already added in the loci build-process,
as it is not a dependency of any openstack service