### PR TITLE
Bump libvirt

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -209,7 +209,7 @@ textfsm===1.1.2
 python-3parclient===4.2.12
 unittest2===1.1.0
 django-compressor===2.4.1
-libvirt-python===7.6.0
+libvirt-python===8.0.0
 python-zunclient===4.3.0
 tzlocal===2.1
 sphinxcontrib-jsmath===1.0.1


### PR DESCRIPTION
Apparently, one should install the version from
the os, but since we run things in containers,
I'll bump it to the version in SLES15SP4
Possibly, I'll have to do the same when
we switch over to garden linux