### PR TITLE
Bump PyYAML due to yaml/pyyaml#724

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -178,7 +178,7 @@ python-subunit===1.4.0
 tornado===6.2
 pycparser===2.21
 mock===4.0.3
-PyYAML===6.0
+PyYAML===6.0.1
 beautifulsoup4===4.11.1
 os-net-config===15.2.0
 ovs===2.17.1.post1


### PR DESCRIPTION
Cython 3 came out with breaking changes, but PyYAML didn't pin the major version in the build process.

Change-Id: I055d9575c237775c0e8de8901ec109f118a3eada