### PR TITLE
Add/Pin crc<7.0.0

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -601,3 +601,4 @@ sphinxcontrib-applehelp===1.0.4
 scikit-learn===1.2.2
 raven @ git+https://github.com/sapcc/raven-python.git@ccloud
 pyroscope-io===0.8.1
+crc<7.0.0


### PR DESCRIPTION
- Barbican/Glance images are failing due to :

```
crc16 = crc.Calculator(crc.Crc16.CCITT)
AttributeError: CCITT
```

- Further info : https://github.com/schlitzered/pyredis/issues/10