### PR TITLE
Bump libvirt-python

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -209,7 +209,7 @@ textfsm===1.1.2
 python-3parclient===4.2.12
 unittest2===1.1.0
 django-compressor===2.4.1
-libvirt-python===8.0.0
+libvirt-python===10.6.0
 python-zunclient===4.3.0
 tzlocal===2.1
 sphinxcontrib-jsmath===1.0.1


### PR DESCRIPTION
A later version is needed to support the "libvirt-maxphysaddr",
otherwise we are limited to 40bit (~ 1TiB RAM).

Change-Id: I699efc33d78f72cfde3dadfa18e204bee3ad06a8