### PR TITLE
Bump libvirt-python

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -202,7 +202,7 @@ textfsm===1.1.0
 python-3parclient===4.2.11
 unittest2===1.1.0
 django-compressor===2.4
-libvirt-python===7.1.0
+libvirt-python===10.6.0
 python-zunclient===4.2.0
 tzlocal===2.1
 sphinxcontrib-jsmath===1.0.1


### PR DESCRIPTION
A later version is needed to support the "libvirt-maxphysaddr", otherwise we are limited to 40bit (~ 1TiB RAM).

Change-Id: I699efc33d78f72cfde3dadfa18e204bee3ad06a8