### PR TITLE
Update packaging constraint to match 2023.2

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -335,7 +335,7 @@ testscenarios===0.5.0
 sphinxcontrib-pecanwsme===0.10.0
 sadisplay===0.4.9
 infinisdk===206.1.2
-packaging===21.3
+packaging===23.1
 XStatic-Dagre-D3===0.4.17.0
 nose-exclude===0.5.0
 psutil===5.9.2


### PR DESCRIPTION
A recent release of setuptools breaks when packaging is <22.0 [0]. Because we can't reliably pin setuptools in the real world (we expect people to simple create a venv and pip install from there (with our without tools like tox) we update our stable constraint to 23.1 to match stable/2023.2 in order to get things working again.

[0] https://github.com/pypa/setuptools/issues/4483

Change-Id: If75a86941b636580b5220f9ea5fa80a12d1bf2e6