### PR TITLE
Bump urllib3

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -183,7 +183,7 @@ ifaddr===0.1.7
 reno===3.5.0
 imagesize===1.3.0
 pydot===1.4.2
-urllib3===1.26.8
+urllib3===1.26.12
 graphviz===0.19.1
 PyKMIP===0.10.0
 whereto===0.4.0


### PR DESCRIPTION
Bump urllib3 to support the installation of sentry-sdk, which requires urllib3 >= 1.26.11