### PR TITLE
Bump oslo.reports for Xena

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -383,7 +383,7 @@ python-qpid-proton===0.35.0
 python-octaviaclient===2.4.0
 pysaml2===7.0.1
 requests-oauthlib===1.3.0
-oslo.reports===2.3.0
+oslo.reports===2.4.0
 bitmath===1.3.3.1
 ceilometermiddleware===2.3.0
 # python-nss===1.0.1 Unused in projects still on xena


### PR DESCRIPTION
oslo.reports 2.4.0 contains a serialization fix for Guru Mediation Reports

[Support integer keys of dicts in text serialization](https://github.com/openstack/oslo.reports/commit/68bc329964fa7819c076d7dfcadb76f5d2cf130e)