### PR TITLE
sapcc: switch to custom oslo.db for Xena

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -474,7 +474,8 @@ XStatic-Angular-FileUpload===12.0.4.0
 python-openstackclient===5.6.0
 pyzmq===22.2.1
 nocaselist===1.0.4
-oslo.db===11.0.0
+#oslo.db===11.0.0
+oslo.db @ git+https://github.com/sapcc/oslo.db.git@stable/xena-m3
 simplegeneric===0.8.1
 python-pcre===0.7
 yappi===1.4.0


### PR DESCRIPTION
This includes fix for MariaDB/Galera

exc_filters: Handle OperationalError for MariaDB/Galera

https://review.opendev.org/q/I6ff3667b35ea38a2d3c258f810a55eda9abe465e
