### PR TITLE
sapcc: switch to custom oslo.db for Yoga

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -507,7 +507,8 @@ XStatic-Angular-FileUpload===12.0.4.0
 python-openstackclient===5.8.0
 pyzmq===21.0.2
 nocaselist===1.0.4
-oslo.db===11.2.0
+#oslo.db===11.2.0
+oslo.db @ git+https://github.com/sapcc/oslo.db.git@stable/yoga-m3
 simplegeneric===0.8.1
 python-pcre===0.7
 yappi===1.3.3


### PR DESCRIPTION
This includes fix for MariaDB/Galera

exc_filters: Handle OperationalError for MariaDB/Galera