### PR TITLE
sapcc: bump oslo.db for 2023.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -470,7 +470,7 @@ XStatic-Angular-FileUpload===12.0.4.0
 python-openstackclient===6.2.0
 pyzmq===20.0.0
 nocaselist===1.0.6
-oslo.db===12.3.2
+oslo.db===12.3.3
 simplegeneric===0.8.1
 python-pcre===0.7
 yappi===1.4.0


### PR DESCRIPTION
This includes fix for MariaDB/Galera

exc_filters: Handle OperationalError for MariaDB/Galera