### PR TITLE
Remove os-brick constraint

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -248,7 +248,6 @@ funcparserlib===1.0.0
 passlib===1.7.4
 dib-utils===0.0.11
 cliff===4.2.0
-os-brick===6.2.3
 ansible-runner===2.2.1
 pytz-deprecation-shim===0.1.0.post0
 scp===0.14.4


### PR DESCRIPTION
We're installing our own version of os-brick via git repo as custom requirement and thus don't rely on any versioning.