### PR TITLE
Bump urllib3 to 1.26.11

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -183,7 +183,7 @@ ifaddr===0.1.7
 reno===3.5.0
 imagesize===1.3.0
 pydot===1.4.2
-urllib3===1.26.8
+urllib3===1.26.11
 graphviz===0.19.1
 PyKMIP===0.10.0
 whereto===0.4.0


### PR DESCRIPTION
We want to switch from `raven` to `sentry_sdk` which requires `urllib3` to be 1.26.11 or greater. Looking at the changelog [0] for `urllib3`, there are only fixes between the old .8 to the new .11 - which should make this bump safe.

[0] https://github.com/urllib3/urllib3/blob/main/CHANGES.rst#12611-2022-07-25