### PR TITLE
[Cinder] Bump PyMySQL to 1.1.1

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -397,7 +397,7 @@ zake===0.2.2
 python-rsdclient===1.0.2
 flux===1.3.5
 python-solumclient===3.3.0
-PyMySQL===1.0.2
+PyMySQL===1.1.1
 uhashring===2.0
 kubernetes===12.0.1
 httplib2===0.19.0


### PR DESCRIPTION
This addresses a vulnerability in the older pymysql.