### PR TITLE
Update upper-constraints.txt

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -590,3 +590,4 @@ scikit-learn===1.1.2
 pytest-cov===4.0.0
 raven @ git+https://github.com/sapcc/raven-python.git@ccloud
 pyroscope-io===0.8.1
+crc<7.0.0


### PR DESCRIPTION
Cinder API is failing due to an incompatibility with crc >= 7.0.0 the python-redis package hasn't updated to take care of the changes in the crc>=7.0.0 upgrade.

This patch pins crc to < 7.0.0