### PR TITLE
Update ironicclient for custom repo

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -472,7 +472,7 @@ falcon===3.1.1
 etcd3gw===2.1.0
 Flask-RESTful===0.3.9
 GitPython===3.1.31
-python-ironicclient===5.4.0
+python-ironicclient>=5.4.0,<5.4.2
 XStatic===1.0.3
 XStatic-Angular-FileUpload===12.2.13.0
 python-openstackclient===6.3.0


### PR DESCRIPTION
The custom repo's version will be 5.4.1.dev1 so we accept that in addition to 5.4.0.