### PR TITLE
remove os-brick constraint

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -249,7 +249,6 @@ influxdb===5.3.2
 funcparserlib===2.0.0a0
 passlib===1.7.4
 cliff===4.9.1
-os-brick===6.11.0
 scp===0.15.0
 python-zaqarclient===3.0.0
 ldappool===3.0.0


### PR DESCRIPTION
We're installing our own version of os-brick via git repo as custom requirement and thus don't rely on any versioning.