### PR TITLE
Bump osprofiler 2023.2 edition

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -22,7 +22,7 @@ os-api-ref===3.0.0
 python-ldap===3.4.3
 oslo.concurrency===5.2.0
 websocket-client===1.5.1
-osprofiler===4.1.0
+osprofiler===4.4.0  # For otlp support
 os-resource-classes===1.1.0
 tabulate===0.9.0
 python-ironic-inspector-client===5.0.0


### PR DESCRIPTION
The release adds OTPL support, but drops Jaeger support.

The lowest supported python version is 3.10, which is the version Jaammy and therefore Antelope and Bobcat still run on.

Otherwise the code-changes is are largely stylistic.

Change-Id: I3f793edbc7a651b308f1d5adb592a07ede053ab1