### PR TITLE
Bump osprofiler constraint to 4.4.0 (SQLAlchemy 2.x compatibility)

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -21,7 +21,7 @@ os-api-ref===3.1.0
 python-ldap===3.4.4
 oslo.concurrency===7.2.0
 websocket-client===1.8.0
-osprofiler===4.3.0
+osprofiler===4.4.0
 os-resource-classes===1.1.0
 mypy_extensions===1.1.0
 tabulate===0.9.0


### PR DESCRIPTION
osprofiler 4.2.0 and 4.3.0 use `exception_context.chained_exception` in their SQLAlchemy `handle_error` hook. This attribute was removed in SQLAlchemy 2.x, causing every DB call during an OpenStack service request to crash with:

```
AttributeError: 'ExceptionContextImpl' object has no attribute 'chained_exception'
```

osprofiler 4.4.0 is the first release with the fix, replacing `chained_exception` access with `exception_context.original_exception.__cause__`, which is compatible with SQLAlchemy 2.0+.

Affects any deployment with `OSPROFILER_TRACE_SQLALCHEMY=True` (the devstack default) on a branch that pins SQLAlchemy >= 2.0.