### PR TITLE
Remove stale purestorage constraints blocking loci build

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -90,7 +90,7 @@ infi.dtypes.wwn===0.1.1
 rpm-vercmp===0.1.2
 python-freezerclient===5.2.0
 python-vitrageclient===5.1.1
-py-pure-client===1.55.0
+# py-pure-client===1.55.0  # purestorage loci profile dropped Oct 2025; conflicts with setuptools<70
 krest===1.3.6
 psycopg2===2.9.9
 networkx===3.1;python_version=='3.8'
@@ -309,7 +309,7 @@ selenium===3.141.0
 mistral-lib===3.0.0
 dogtag-pki===11.2.1
 XStatic-Angular-UUID===0.0.4.0
-purestorage===1.19.0
+# purestorage===1.19.0  # purestorage loci profile dropped Oct 2025
 sphinxcontrib-seqdiag===3.0.0
 os-win===5.9.0
 capacity===1.3.14


### PR DESCRIPTION
The purestorage loci profile was dropped from cinder and nova in Oct 2025, so `py-pure-client` and `purestorage` are no longer installed. `py-pure-client===1.55.0` requires `setuptools>=70.0.0`, conflicting with the `setuptools<70` constraint and breaking the dalmatian requirements image build since July 3.