### PR TITLE
Use own keystoneauth fork with support for HTTP 429.

### DIFF
--- a/upper-constraints.txt
+++ b/upper-constraints.txt
@@ -538,7 +538,7 @@ ws4py===0.5.1
 flexcache===0.3;python_version>='3.9'
 sphinxcontrib-qthelp===1.0.3;python_version=='3.8'
 sphinxcontrib-qthelp===2.0.0;python_version>='3.9'
-keystoneauth1===5.8.0
+keystoneauth1 @ git+https://github.com/sapcc/keystoneauth.git@stable/2024.2-m3
 statsd===4.0.1
 proto-plus===1.24.0
 python-keystoneclient===5.5.0


### PR DESCRIPTION
The upstream keystoneauth doesn't support rate-limiting. When user is ratelimited by Keystone the correct exception should be raised.

429 Exception is implemented in https://github.com/sapcc/keystoneauth/pull/1